### PR TITLE
Fix PHP 7 compatibility in carousel builder

### DIFF
--- a/kiss-automagical-carousel-builder.php
+++ b/kiss-automagical-carousel-builder.php
@@ -60,8 +60,10 @@ add_filter( 'the_content', function ( $html ) {
 		      ? $img->parentNode
 		      : $img;
 
-		$nxt = $node->nextSibling;
-		while ( $is_ws( $nxt ) ) $nxt = $nxt?->nextSibling;
+                $nxt = $node->nextSibling;
+                while ( $is_ws( $nxt ) ) {
+                        $nxt = $nxt ? $nxt->nextSibling : null;
+                }
 
 		$is_next_img = $nxt instanceof DOMElement && (
 			$nxt->nodeName === 'img' ||


### PR DESCRIPTION
## Summary
- fix `the_content` filter for PHP 7 by removing the nullsafe operator

## Testing
- `npm test` *(fails: could not find package.json)*