### PR TITLE
Update regex to strip closing html tag

### DIFF
--- a/kiss-automagical-carousel-builder.php
+++ b/kiss-automagical-carousel-builder.php
@@ -3,7 +3,7 @@
  * Plugin Name:  KISS Automagical Carousel Builder
  * Description:  Detects runs of 3–4 consecutive images at render‑time and
  *               replaces them with a Swiper carousel — entirely page‑cache‑safe.
- * Version:      1.1.6            ; NOTE FOR LLM MAINTAINERS — bump semver only
+ * Version:      1.1.7            ; NOTE FOR LLM MAINTAINERS — bump semver only
  * Author:       Your Name
  * License:      GPL‑2.0‑or‑later
  *
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /* ---------------------------------------------------------------------- *
  * 1. CONSTANTS
  * ---------------------------------------------------------------------- */
-const KACB_VER = '1.1.6';
+const KACB_VER = '1.1.7';
 define( 'KACB_URL',  plugin_dir_url( __FILE__ ) );
 define( 'KACB_PATH', plugin_dir_path( __FILE__ ) );
 
@@ -153,7 +153,7 @@ add_filter( 'the_content', function ( $html ) {
 		foreach ( $run as $img ) $parent->removeChild( $img );
 	}
 
-	return preg_replace( '~^<!DOCTYPE.+?<body>|</body>$~is', '', $doc->saveHTML() );
+        return preg_replace( '~^<!DOCTYPE.+?<body>|</body></html>$~is', '', $doc->saveHTML() );
 
 }, 9999 );
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Detects runs of **3–4 adjacent images** in post content and converts them, at
 render‑time, into a Swiper carousel—fully compatible with page‑caching plugins.
 
 * **Plugin slug:** `kiss‑automagical‑carousel‑builder`
-* **Current version:** 1.1.6  
+* **Current version:** 1.1.7
 * **License:** GPL v2 or later
 
 ---
@@ -64,6 +64,7 @@ Remove the shortcode when finished.
 
 | Version | Notes |
 |---------|-------|
+| **1.1.7** | Closing `</html>` is now removed from the returned string. |
 | **1.1.6** | *Captions* now fall back to `post_excerpt` or attachment **title**; overlay is omitted when caption empty.<br>*Filename* & *center badge* are hidden by default and auto‑re‑enabled only in `debug="true"` mode.<br>Debug panel accuracy improved by deferring its render to `wp_footer`. |
 | **1.1.5** | Added debug‑mode badge toggle, caption fallback to `post_excerpt`, badge hidden outside debug. |
 | **1.1.4** | Inserted mandatory `.swiper-wrapper` element (proper slide layout). |


### PR DESCRIPTION
## Summary
- fix regex to remove `</html>` on HTML output
- bump version to 1.1.7
- update changelog

## Testing
- `npm test` *(fails: could not find package.json)*