### PR TITLE
Add WordPress unit test for carousel filter

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="KACB Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+    $_tests_dir = '/tmp/wordpress-tests-lib';
+}
+require_once $_tests_dir . '/includes/functions.php';
+function _manually_load_plugin() {
+    require dirname( dirname( __FILE__ ) ) . '/kiss-automagical-carousel-builder.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-carousel.php
+++ b/tests/test-carousel.php
@@ -1,0 +1,9 @@
+<?php
+class CarouselBuilderTest extends WP_UnitTestCase {
+    function test_filter_removes_html_body() {
+        $html  = '<img src="a.jpg" /><img src="b.jpg" /><img src="c.jpg" />';
+        $output = apply_filters( 'the_content', $html );
+        $this->assertStringNotContainsString( '<html', $output );
+        $this->assertStringNotContainsString( '<body', $output );
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit configuration for WP tests
- add bootstrap file for WordPress test suite
- create new unit test verifying that the filter output lacks `<html>` and `<body>` tags

## Testing
- `phpunit` *(fails: command not found)*