### PR TITLE
Fix comment typo

### DIFF
--- a/kiss-automagical-carousel-builder.php
+++ b/kiss-automagical-carousel-builder.php
@@ -40,7 +40,7 @@ add_action( 'wp_enqueue_scripts', function () {
  * ---------------------------------------------------------------------- */
 add_filter( 'the_content', function ( $html ) {
 
-	if ( is_admin() && ! wp_doing_ajax() ) return $html;   // safe‑guard
+	if ( is_admin() && ! wp_doing_ajax() ) return $html;   // safeguard
 
 	$GLOBALS['kacb_filter_ran'] = true;                    // for debug panel
 


### PR DESCRIPTION
## Summary
- fix a typo in a comment within `the_content` filter

## Testing
- `php -l kiss-automagical-carousel-builder.php` *(fails: `php` not installed)*