### PR TITLE
Allow carousels with two images

### DIFF
--- a/kiss-automagical-carousel-builder.php
+++ b/kiss-automagical-carousel-builder.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * Plugin Name:  KISS Automagical Carousel Builder
- * Description:  Detects runs of 3–4 consecutive images at render‑time and
+ * Description:  Detects runs of 2–4 consecutive images at render‑time and
  *               replaces them with a Swiper carousel — entirely page‑cache‑safe.
- * Version:      1.2.0            ; NOTE FOR LLM MAINTAINERS — bump semver only
+ * Version:      1.2.1            ; NOTE FOR LLM MAINTAINERS — bump semver only
  * Author:       KISS Plugins
  * License:      GPL‑2.0‑or‑later
  *
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /* ---------------------------------------------------------------------- *
  * 1. CONSTANTS
  * ---------------------------------------------------------------------- */
-const KACB_VER = '1.2.0';
+const KACB_VER = '1.2.1';
 define( 'KACB_URL',  plugin_dir_url( __FILE__ ) );
 define( 'KACB_PATH', plugin_dir_path( __FILE__ ) );
 
@@ -77,10 +77,10 @@ add_filter( 'the_content', function ( $html ) {
 
 		$buff[] = $img;
 
-		if ( ! $is_next_img ) {
-			if ( count( $buff ) >= 3 && count( $buff ) <= 4 ) $runs[] = $buff;
-			$buff = [];
-		}
+                if ( ! $is_next_img ) {
+                        if ( count( $buff ) >= 2 && count( $buff ) <= 4 ) $runs[] = $buff;
+                        $buff = [];
+                }
 	}
 
 	$GLOBALS['kacb_runs_found'] = count( $runs );

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 # KISS Automagical Carousel Builder
 
-Detects runs of **3–4 adjacent images** in post content and converts them, at
+Detects runs of **2–4 adjacent images** in post content and converts them, at
 render‑time, into a Swiper carousel—fully compatible with page‑caching plugins.
 
 * **Plugin slug:** `kiss‑automagical‑carousel‑builder`
-* **Current version:** 1.1.8
+* **Current version:** 1.2.1
 * **License:** GPL v2 or later
 
 ---
@@ -24,7 +24,7 @@ render‑time, into a Swiper carousel—fully compatible with page‑caching plu
 ## How it works
 
 * On each front‑end request, the plugin looks for `<img>` tags that are
-  **immediately adjacent** (whitespace allowed) and groups of three or four.
+  **immediately adjacent** (whitespace allowed) and groups of two to four.
 * The group is replaced with Swiper markup:
   * **Top overlay** — *file name* (hidden by default)  
   * **Center badge** — `1 / 3`, `2 / 3`, … (hidden by default)  
@@ -38,7 +38,7 @@ render‑time, into a Swiper carousel—fully compatible with page‑caching plu
 
 ## Usage
 
-1. In Classic or Gutenberg, place **three or four images** of the same size so
+1. In Classic or Gutenberg, place **two, three or four images** of the same size so
    they abut each other.
 2. Publish/Update → view the front end.
 
@@ -81,7 +81,7 @@ Remove the shortcode when finished.
   .kacb-filename { display:block !important; }
   ```
 * **Change slide counter styling** — target `.kacb-indicator`.
-* **Adjust detection window** — edit `>= 3 && <= 4` in the filter if you’d
+* **Adjust detection window** — edit `>= 2 && <= 4` in the filter if you’d
   like larger carousels.
 
 ---

--- a/tests/test-carousel.php
+++ b/tests/test-carousel.php
@@ -6,4 +6,10 @@ class CarouselBuilderTest extends WP_UnitTestCase {
         $this->assertStringNotContainsString( '<html', $output );
         $this->assertStringNotContainsString( '<body', $output );
     }
+
+    function test_two_images_create_carousel() {
+        $html  = '<img src="a.jpg" /><img src="b.jpg" />';
+        $output = apply_filters( 'the_content', $html );
+        $this->assertStringContainsString( 'kacb-carousel', $output );
+    }
 }


### PR DESCRIPTION
## Summary
- allow 2–4 consecutive images to form a carousel
- bump version to 1.2.1
- update documentation for new image threshold
- add unit test covering two-image runs

## Testing
- `phpunit` *(fails: command not found)*